### PR TITLE
added progression circles with fontawesome

### DIFF
--- a/app/views/guided/entries/new.html.erb
+++ b/app/views/guided/entries/new.html.erb
@@ -5,6 +5,9 @@
       <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[0].id } %>
     <% end %>
     <div id="next-1" class="btn btn-primary">Next</div>
+    <i class="fas fa-circle"></i>
+    <i class="far fa-circle"></i>
+    <i class="far fa-circle"></i>
   </div>
   <div id="second-question" class="d-none">
     <%= f.fields_for :answer_2 do |fa| %>
@@ -12,13 +15,19 @@
       <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[1].id } %>
     <% end %>
     <div id="next-2" class="btn btn-primary">Next</div>
+    <i class="far fa-circle"></i>
+    <i class="fas fa-circle"></i>
+    <i class="far fa-circle"></i>
   </div>
   <div id="third-question" class="d-none">
     <%= f.fields_for :answer_3 do |fa| %>
       <%= fa.input :content, label: "#{@questions[2].content}" %>
       <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[2].id } %>
     <% end %>
-    <%= f.button :submit %>
+    <%= f.button :submit, "Next", class: "btn btn-primary" %>
+    <i class="far fa-circle"></i>
+    <i class="far fa-circle"></i>
+    <i class="fas fa-circle"></i>
   </div>
 <% end %>
 <%= link_to 'Go back to home page', root_path  %>


### PR DESCRIPTION
They are not styled at all but they are there and they work.
<img width="297" alt="Screen Shot 2021-05-26 at 3 11 01 PM" src="https://user-images.githubusercontent.com/77209045/119717752-b63d9c80-be34-11eb-8dbc-dbce95276234.png">
<img width="228" alt="Screen Shot 2021-05-26 at 3 11 07 PM" src="https://user-images.githubusercontent.com/77209045/119717750-b63d9c80-be34-11eb-95d7-2ec0df48d398.png">
<img width="416" alt="Screen Shot 2021-05-26 at 3 11 14 PM" src="https://user-images.githubusercontent.com/77209045/119717748-b5a50600-be34-11eb-860b-f1e0817e8966.png">

I also changed the text for the submit button so it looks consistent across the guide.