### PR TITLE
added background color to trix buttons and fixed emoji css file form …

### DIFF
--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -85,4 +85,5 @@ trix-editor.form-control {
   height: 32px !important;
   flex-grow: 1 !important;
   padding: 16px !important;
+  background-color: $light-gray !important;
 }

--- a/app/assets/stylesheets/components/_emoji.scss
+++ b/app/assets/stylesheets/components/_emoji.scss
@@ -1,8 +1,8 @@
-// .emoji {
-//   font-size: 60px;
-//   color: $light-gray;
-//   padding: 8px 8px;
-//   // &:active {
-//   //   color: $dark-green;
-//   // }
-// }
+.emoji {
+  font-size: 60px;
+  color: $light-gray;
+  padding: 8px 8px;
+  &:active {
+    color: $dark-green;
+  }
+}

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -22,12 +22,3 @@
   }
 }
 
-.emoji {
-  font-size: 60px;
-  color: $light-gray;
-  padding: 8px 8px;
-  // &:active {
-  //   color: $dark-green;
-  // }
-}
-


### PR DESCRIPTION
…before


@daniel-silverman : as discussed, to give the buttons a light-gray background:
<img width="397" alt="Screen Shot 2021-05-27 at 4 48 14 PM" src="https://user-images.githubusercontent.com/77209045/119895085-5fef5d00-bf0b-11eb-8e06-96909084d60c.png">
