### PR TITLE
Remove unlink btn

### DIFF
--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -42,7 +42,7 @@ trix-editor.form-control {
 
 .trix-button-group--history-tools, .trix-button--icon-italic, .trix-button--icon-strike,
 .trix-button--icon-quote, .trix-button--icon-code, .trix-button--icon-decrease-nesting-level,
-.trix-button--icon-increase-nesting-level, .trix-button--dialog {
+.trix-button--icon-increase-nesting-level, .trix-button--dialog:last-child {
   display: none !important;
 }
 
@@ -90,8 +90,4 @@ trix-editor.form-control {
 
 .link_to_embed {
   color: $dark-gray;
-}
-
-trix-toolbar .trix-input--dialog {
-  margin: 0 !important;
 }

--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -87,3 +87,7 @@ trix-editor.form-control {
   padding: 16px !important;
   background-color: $light-gray !important;
 }
+
+.link_to_embed {
+  color: $dark-gray;
+}

--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -91,3 +91,7 @@ trix-editor.form-control {
 .link_to_embed {
   color: $dark-gray;
 }
+
+trix-toolbar .trix-input--dialog {
+  margin: 0 !important;
+}

--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -42,7 +42,7 @@ trix-editor.form-control {
 
 .trix-button-group--history-tools, .trix-button--icon-italic, .trix-button--icon-strike,
 .trix-button--icon-quote, .trix-button--icon-code, .trix-button--icon-decrease-nesting-level,
-.trix-button--icon-increase-nesting-level{
+.trix-button--icon-increase-nesting-level, .trix-button--dialog {
   display: none !important;
 }
 

--- a/app/javascript/components/init_trix.js
+++ b/app/javascript/components/init_trix.js
@@ -3,9 +3,9 @@ import "trix/dist/trix.css"
 const embedBtnSnippet = (element) => {
   return `
   <div data-behavior="embed_container">
-    <div class="d-flex align-items-center mt-2 link_to_embed link_to_embed--new">
+    <div class="d-flex justify-content-center align-items-center mt-2 link_to_embed link_to_embed--new">
       Would you like to embed media from this site?
-      <input type="button" class="btn-sm border border-dark rounded btn-muted ml-1" data-behavior="embed_url" value="OK, embed it!">
+      <input type="button" class="btn-sm border border-dark rounded btn-muted ml-3" data-behavior="embed_url" value="Embed!">
     </div>
   </div>
   `;


### PR DESCRIPTION
<img width="374" alt="Screen Shot 2021-05-31 at 10 13 49 AM" src="https://user-images.githubusercontent.com/77209045/120206292-059b1880-c1f9-11eb-8123-c94f4a1d1db9.png">

@daniel-silverman , this is what I've done:

- Removed the Unlink button which is not necessary
- Made the text for embed dark-gray
- Changed the embed btn text to something shorter
- centered the embed div