### PR TITLE
implemented spotify embed similar to youtube embed, with model/contro…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'cloudinary', '~> 1.16.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'devise'
+gem 'ruby-oembed', '~> 0.15.0'
 
 gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    ruby-oembed (0.15.0)
     ruby-vips (2.1.2)
       ffi (~> 1.12)
     rubyzip (2.3.0)
@@ -285,6 +286,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
   redis (~> 4.0)
+  ruby-oembed (~> 0.15.0)
   sass-rails (>= 6)
   selenium-webdriver
   simple_form

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -1,0 +1,9 @@
+class SpotifyController < ApplicationController
+  def show
+    @spotify = Spotify.new(id: params[:id])
+    render json: {
+      sgid: @spotify.attachable_sgid,
+      content: render_to_string(partial: "spotifies/thumbnail", locals: { spotify: @spotify }, formats: [:html])
+    }
+  end
+end

--- a/app/javascript/components/trix_embed_controller.js
+++ b/app/javascript/components/trix_embed_controller.js
@@ -10,6 +10,7 @@ Trix.config.blockAttributes.heading2 = {
 class TrixEmbedController {
   constructor(element) {
     this.pattern = /^https:\/\/([^\.]+\.)?youtube\.com\/watch\?v=(.*)/
+    this.spotpattern = /^https:\/\/([^\.]+\.)?open.spotify\.com\/track\/(.*)(\?.*)$/
     this.element = element
     this.editor = element.editor
     this.toolbar = element.toolbarElement
@@ -28,8 +29,11 @@ class TrixEmbedController {
   didInput(event) {
     let value = event.target.value.trim()
     let matches = value.match(this.pattern)
+    let spotmatches = value.match(this.spotpattern)
     if (matches != null) {
       this.fetch(matches[2])
+    } else if (spotmatches != null) {
+      this.spotfetch(spotmatches[2])
     } else {
       this.reset()
     }
@@ -37,6 +41,14 @@ class TrixEmbedController {
   fetch(value) {
     Rails.ajax({
       url: `/youtube/${encodeURIComponent(value)}`,
+      type: 'get',
+      error: this.reset.bind(this),
+      success: this.showEmbed.bind(this)
+    })
+  }
+   spotfetch(value) {
+    Rails.ajax({
+      url: `/spotify/${encodeURIComponent(value)}`,
       type: 'get',
       error: this.reset.bind(this),
       success: this.showEmbed.bind(this)

--- a/app/models/spotify.rb
+++ b/app/models/spotify.rb
@@ -1,0 +1,25 @@
+require 'oembed'
+
+class Spotify
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include GlobalID::Identification
+  include ActionText::Attachable
+
+  attribute :id
+
+  def self.find(id)
+    new(id: id)
+  end
+
+  def thumbnail
+    OEmbed::Providers.register_all
+    resource = OEmbed::Providers.get("https://open.spotify.com/track/#{id}")
+    # using existing oembed method for thumbnail url
+    resource.thumbnail_url
+  end
+
+  def to_trix_content_attachment_partial_path
+    "spotifies/thumbnail"
+  end
+end

--- a/app/views/spotifies/_spotify.html.erb
+++ b/app/views/spotifies/_spotify.html.erb
@@ -1,0 +1,3 @@
+<div id="spotify-container">
+  <iframe id="spotplayer" src="https://open.spotify.com/embed/track/<%= spotify.id %>" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+</div>

--- a/app/views/spotifies/_thumbnail.html.erb
+++ b/app/views/spotifies/_thumbnail.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= image_tag spotify.thumbnail, style: "max-width: 85%" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   resources :youtube, only: :show
+  resources :spotify, only: :show
 
   resources :communities
   resources :communities, only: :show do


### PR DESCRIPTION
…ller/views and small modification to the embed controller js

@daniel-silverman :
- Added option to embed spotify tracks (not playlist!) the same way we embed youtube videos
- it will create a conflict with my other PR since I also touched the regex stuff in JS but I can fix it when the other PR is merged

<img width="376" alt="Screen Shot 2021-05-31 at 11 53 39 AM" src="https://user-images.githubusercontent.com/77209045/120217947-10f54080-c207-11eb-8e4e-6c5372582a07.png">
<img width="302" alt="Screen Shot 2021-05-31 at 11 53 29 AM" src="https://user-images.githubusercontent.com/77209045/120217960-15b9f480-c207-11eb-8ac2-f2e4a658a1e0.png">


