### PR TITLE
changed youtube icon for more general play icon

### DIFF
--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -47,7 +47,7 @@ trix-editor.form-control {
 }
 
 .trix-button--icon-link::before {
-  background-image: url('https://res.cloudinary.com/dsqxc7oqa/image/upload/v1622079575/youtube-brands_hwdyv6.svg') !important;
+  background-image: url('https://res.cloudinary.com/dsqxc7oqa/image/upload/v1622477057/play-circle-solid_cr5bkm.svg') !important;
 }
 
 .trix-button--icon-attach::before {


### PR DESCRIPTION
Changed youtube icon for a more general Play icon, since we can now add both youtube videos and spotify songs:

<img width="375" alt="Screen Shot 2021-05-31 at 12 06 44 PM" src="https://user-images.githubusercontent.com/77209045/120219147-bfe64c00-c208-11eb-8855-148fa2e5d7a9.png">

@daniel-silverman What do you think?