### PR TITLE
Remove 'X' from top left corner of guided card

### DIFF
--- a/app/assets/stylesheets/pages/_guided_entry_new.scss
+++ b/app/assets/stylesheets/pages/_guided_entry_new.scss
@@ -5,21 +5,3 @@
   position: relative;
 }
 
-.navbar {
-}
-
-.cancel {
-  position: absolute;
-  top: 70px;
-  left: 30px;
-  font-size: 24px;
-  color: $light-gray;
-  // background-color: $light-gray;
-  // height: 30px;
-  // width: 30px;
-  // border-radius: 50%;
-  &:hover {
-    color: $dark-green;
-    text-decoration: none;
-  }
-}

--- a/app/views/guided/entries/new.html.erb
+++ b/app/views/guided/entries/new.html.erb
@@ -7,8 +7,8 @@
           <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[0].id } %>
         <% end %>
         <br>
-        <%= link_to "Back", menu_path, class: "btn button-sm"  %>
-        <div id="next-1" class="btn button-sm">Next</div>
+        <%= link_to "Back", menu_path, class: "btn button-sm mx-3"  %>
+        <div id="next-1" class="btn button-sm mx-3">Next</div>
         <br>
         <br>
         <i class="fas fa-circle"></i>
@@ -21,8 +21,8 @@
           <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[1].id } %>
         <% end %>
         <br>
-        <div id="back-2" class="btn button-sm">Back</div>
-        <div id="next-2" class="btn button-sm">Next</div>
+        <div id="back-2" class="btn button-sm mx-3">Back</div>
+        <div id="next-2" class="btn button-sm mx-3">Next</div>
         <br>
         <br>
         <i class="far fa-circle"></i>
@@ -35,8 +35,8 @@
           <%= fa.input :question_id, as: :hidden, input_html: { value: @questions[2].id } %>
         <% end %>
         <br>
-        <div id="back-3" class="btn button-sm">Back</div>
-        <%= f.button :submit, "Next", class: "btn button-sm" %>
+        <div id="back-3" class="btn button-sm mx-3">Back</div>
+        <%= f.button :submit, "Next", class: "btn button-sm mx-3" %>
         <br>
         <br>
         <i class="far fa-circle"></i>
@@ -48,11 +48,4 @@
 </div>
 <br>
 <%#= link_to 'Home', root_path, class: 'button-sm'  %>
-
-<!-- cancel icon-->
-
-<%= link_to root_path, class: 'cancel' do %>
-  <i class="far fa-times-circle"></i>
-<% end %>
-
 


### PR DESCRIPTION
-Removed the "x" from the guided entries card
-Added spacing to the buttons to match the spacing on the entry edit page

@annemano please review/merge when you have a moment. Thank you.

<img width="313" alt="Screen Shot 2021-06-01 at 12 15 59 PM" src="https://user-images.githubusercontent.com/78102899/120357184-2899fb00-c2d3-11eb-8565-d2c56fdd393f.png">
