### PR TITLE
Buttons transition

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,17 +1,15 @@
 .button-lg {
-  // width:170px;
   width:170px;
-  // height: 60px;
   background-color: $dark-green;
   padding: 16px 32px;
   color: $light-gray;
   border-radius: 4px;
   border: 3px solid $dark-green;
   transition: background-color .3s;
-  &:hover {
-    color: $light-gray;
-    text-decoration: none;
-  }
+  // &:hover {
+  //   color: $light-gray;
+  //   text-decoration: none;
+  // }
   &:active {
     color: $light-gray;
     text-decoration: none;
@@ -29,6 +27,21 @@
   border-radius: 8px;
   margin-top: 8px;
   margin-bottom: 8px;
+  &:hover {
+    color: $light-gray
+  }
+}
+
+.button-sm-gray {
+    // width: 110px;
+  // height: 55px;
+  background-color: $light-gray;
+  padding: 8px 16px;
+  color: $dark-gray;
+  border-radius: 8px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+
   &:hover {
     color: $light-gray
   }

--- a/app/assets/stylesheets/components/_card_entry.scss
+++ b/app/assets/stylesheets/components/_card_entry.scss
@@ -1,5 +1,5 @@
 .container-entries {
-  width: 340px;
+  width: 320px;
   margin: 0 auto;
   h1 {
     margin-bottom: 24px;
@@ -48,6 +48,7 @@
 }
 
 .container-editor {
-  width: 380px;
+  // width: 340px;
+  width: 100%;
   margin: 16px auto;
 }

--- a/app/assets/stylesheets/components/_card_entry.scss
+++ b/app/assets/stylesheets/components/_card_entry.scss
@@ -1,5 +1,6 @@
 .container-entries {
-  width: 320px;
+  width: 90vw;
+  max-width: 600px;
   margin: 0 auto;
   h1 {
     margin-bottom: 24px;
@@ -48,7 +49,8 @@
 }
 
 .container-editor {
-  // width: 340px;
-  width: 100%;
+  width: 90vw;
+  max-width: 600px;
+  // width: 100%;
   margin: 16px auto;
 }

--- a/app/assets/stylesheets/components/_card_entry_show.scss
+++ b/app/assets/stylesheets/components/_card_entry_show.scss
@@ -1,5 +1,6 @@
 .container-entry {
-  width: 380px;
+  width: 90vw;
+  max-width: 600px;
   margin: 40px auto;
 }
 

--- a/app/assets/stylesheets/components/_card_guided_entry.scss
+++ b/app/assets/stylesheets/components/_card_guided_entry.scss
@@ -1,7 +1,0 @@
-.card_guided_entry {
-
-}
-
-.form-control {
-  height: 300px !important;
-}

--- a/app/assets/stylesheets/components/_doodle.scss
+++ b/app/assets/stylesheets/components/_doodle.scss
@@ -11,3 +11,10 @@
   height: 30px;
 }
 
+#doodle-options {
+  display: flex;
+  align-content: center;
+  margin: 0 auto;
+  width: 375px;
+}
+

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -26,5 +26,10 @@
   border-radius: 4px;
   border: none;
   text-align: left;
-  background: $light-gray;
+  // background: $light-gray;
+}
+
+.form-inputs {
+  width: 80%;
+  margin: 0 auto;
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, "Update" %>
+    <%= f.button :submit, "Update", class: 'button-lg' %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
+    <%= f.button :submit, "Sign up", class: 'button-lg' %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
+    <%= f.button :submit, "Log in", class: 'button-lg' %>
   </div>
 <% end %>
 

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -1,10 +1,11 @@
-<div class="container-editor">
-  <%= simple_form_for(@entry) do |f| %>
-    <%= f.input :content, as: :rich_text_area, placeholder: "Take a few deep breaths and consider the positive things that are happening today.", label: false %>
-    <div class="buttons">
-      <%= link_to 'Back', menu_path, class: 'btn mx-3 button-sm' %>
-      <%= f.button :submit, "Post", class: 'btn mx-3 button-sm'  %>
-    </div>
-  <% end %>
+<div class="container">
+  <div class="container-editor">
+    <%= simple_form_for(@entry) do |f| %>
+      <%= f.input :content, as: :rich_text_area, placeholder: "Take a few deep breaths and consider the positive things that are happening today.", label: false %>
+      <div class="buttons">
+        <%= link_to 'Back', menu_path, class: 'btn mx-3 button-sm' %>
+        <%= f.button :submit, "Post", class: 'btn mx-3 button-sm'  %>
+      </div>
+    <% end %>
+  </div>
 </div>
-

--- a/app/views/pages/doodle.html.erb
+++ b/app/views/pages/doodle.html.erb
@@ -4,9 +4,9 @@
 <input id="colors-canvas" type="color" placeholder="Colors">
 <input id="width-canvas" type="range" min="1" max="100">
 <br>
-<div id="doodle-options" class="mt-4">
+<div id="doodle-options" class="d-flex mt-4">
   <%= link_to 'Back', menu_path, class: 'button-sm m-2' %>
-  <div id="restore-canvas" class="btn btn-light m-2">Undo</div>
-  <div id="clear-canvas" class="btn btn-light m-2">Clear</div>
+  <div id="restore-canvas" class="button-sm-gray m-2">Undo</div>
+  <div id="clear-canvas" class="button-sm-gray m-2">Clear</div>
   <a id="save-doodle" download="doodle.jpg" href="" class="button-sm m-2">Save</a>
 </div>

--- a/app/views/pages/doodle.html.erb
+++ b/app/views/pages/doodle.html.erb
@@ -4,7 +4,7 @@
 <input id="colors-canvas" type="color" placeholder="Colors">
 <input id="width-canvas" type="range" min="1" max="100">
 <br>
-<div id="doodle-options" class="d-flex mt-4">
+<div id="doodle-options" class="mt-4">
   <%= link_to 'Back', menu_path, class: 'button-sm m-2' %>
   <div id="restore-canvas" class="button-sm-gray m-2">Undo</div>
   <div id="clear-canvas" class="button-sm-gray m-2">Clear</div>


### PR DESCRIPTION
The title is misleading as this was more general touch ups based on things we talked about throughout the day.

I set the width of the text inputs to look nice with any mobile device (same margins regardless of screen size) and for there to be a max width of 600 so they don't just render across desktop and look silly. @annemano if you have a moment, please take a look.

show:
<img width="305" alt="Screen Shot 2021-06-01 at 3 44 42 PM" src="https://user-images.githubusercontent.com/78102899/120381657-ba643100-c2f0-11eb-9b28-5dd61efb3ebe.png">

edit: 
<img width="301" alt="Screen Shot 2021-06-01 at 3 44 53 PM" src="https://user-images.githubusercontent.com/78102899/120381845-f8615500-c2f0-11eb-83c4-7ab8bb107b4b.png">

guided:
<img width="304" alt="Screen Shot 2021-06-01 at 3 45 17 PM" src="https://user-images.githubusercontent.com/78102899/120381873-feefcc80-c2f0-11eb-9b27-e4d3ae72ab8c.png">

community:
<img width="306" alt="Screen Shot 2021-06-01 at 3 46 06 PM" src="https://user-images.githubusercontent.com/78102899/120381941-0f07ac00-c2f1-11eb-9cb4-6f595e38ab78.png">

doodle (don't know if replacing "undo" and "clear" with icons be better? I tried moving the icons on either side of the slider, but that didn't look nice.):
<img width="295" alt="Screen Shot 2021-06-01 at 3 50 46 PM" src="https://user-images.githubusercontent.com/78102899/120382106-42e2d180-c2f1-11eb-93f7-480ece2d987e.png">