### PR TITLE
removed refresh of page when writing a new message in chat

### DIFF
--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -23,7 +23,7 @@
         <%= render "messages/message", message: message %>
       <% end %>
     </div>
-    <%= simple_form_for [ @community, @message ], remote: true do |f| %>
+    <%= simple_form_for([ @community, @message ], remote: true) do |f| %>
       <%= f.input :content, label: false, placeholder: "Message ##{@community.name}", input_html: { class: "send-message" }  %>
     <% end %>
   </div>


### PR DESCRIPTION
this is not fixing the anchor in the end (Steph is looking into it) but it does fix the AJAX on the chat (no refresh page when posting a message)

@JeanColombel93 