### PR TITLE
Change mood on menu to be more of a back button

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -70,6 +70,24 @@
   }
 }
 
+
+.button-sq-mood {
+  font-size: 26px;
+  background-color: $light-gray;
+  // padding: 24px 24px;
+  width: 112px;
+  height: 64px;
+  text-align: center; line-height: 64px;
+  color: $dark-green;
+  border-radius: 8px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  border: 3px solid $light-gray;
+  position: absolute;
+  bottom: 70px;
+  left: -10px;
+}
+
 .btn-back {
   width: 80px;
   border-radius: 8px;

--- a/app/assets/stylesheets/components/_card_entry.scss
+++ b/app/assets/stylesheets/components/_card_entry.scss
@@ -43,10 +43,16 @@
   align-items: center;
 }
 
-.fa-share, .fa-edit {
+.fa-share {
   font-size: 18px;
   color: $dark-green;
 }
+
+.fa-edit > i {
+  font-size: 18px;
+  color: $dark-green;
+}
+
 
 .container-editor {
   width: 90vw;

--- a/app/assets/stylesheets/components/_card_entry_show.scss
+++ b/app/assets/stylesheets/components/_card_entry_show.scss
@@ -6,7 +6,7 @@
 
 .card_entry_show {
   background-color: $light-gray;
-  width: 100%;
+  width: 90vw;
   padding: 12px 16px;
   margin: 16px auto;
   // text-overflow: hidden;

--- a/app/assets/stylesheets/components/_doodle.scss
+++ b/app/assets/stylesheets/components/_doodle.scss
@@ -16,10 +16,10 @@
 
 #doodle-options {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-content: center;
   margin: 0 auto;
-  width: 375px;
+  width: 90vw;
 }
 
 #colors-canvas {

--- a/app/assets/stylesheets/components/_emoji.scss
+++ b/app/assets/stylesheets/components/_emoji.scss
@@ -14,3 +14,8 @@
   margin-bottom: 8px;
   padding-right: 0;
 }
+
+.emoji-button {
+  font-size: 32px;
+  color: $dark-green;
+}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -6,7 +6,7 @@
   margin-right: 0;
   min-width: 250px
   i {
-    font-size: 20px; // icons on navbar
+    font-size: 24px; // icons on navbar
   }
 }
 
@@ -36,9 +36,6 @@
   padding: 4px 4px;
 }
 
-.plus-icon {
-  font-size: 24px;
-  color: $light-gray;
+#navbarDropdown {
+    font-size: 20px; // avatar icon
 }
-
-

--- a/app/assets/stylesheets/pages/_entry_show.scss
+++ b/app/assets/stylesheets/pages/_entry_show.scss
@@ -11,5 +11,6 @@
   display: flex;
   padding: 12px 16px;
   margin: 16px auto;
+  width: 90vw;
   justify-content: space-between;
 }

--- a/app/assets/stylesheets/pages/_menu.scss
+++ b/app/assets/stylesheets/pages/_menu.scss
@@ -5,6 +5,7 @@
   justify-content: space-around;
   align-items: center;
   height: 80vh;
+  position: relative;
 }
 
 .menu_icon_container {

--- a/app/views/pages/menu.html.erb
+++ b/app/views/pages/menu.html.erb
@@ -24,23 +24,25 @@
     <%= link_to communities_path, class: 'button-sq' do %>
       <i class="fas fa-users"></i>
     <% end %>
-    <%= link_to root_path, class: 'button-sq' do %>
+    <!-- Mood button -->
+    <%= link_to root_path, class: 'button-sq-mood' do %>
+      <i class="fas fa-chevron-left emoji-button"></i>
       <% if @mood == "1"%>
-      <i class="fas fa-meh emoji"></i>
+      <i class="fas fa-meh emoji-button"></i>
       <% elsif @mood == "2" %>
-        <i class="fas fa-smile emoji"></i>
+        <i class="fas fa-smile emoji-button"></i>
       <% elsif @mood == "3" %>
-        <i class="fas fa-angry emoji"></i>
+        <i class="fas fa-angry emoji-button"></i>
       <% elsif @mood == "4" %>
-        <i class="fas fa-frown emoji"></i>
+        <i class="fas fa-frown emoji-button"></i>
       <% elsif @mood == "5" %>
-        <i class="fas fa-sad-tear emoji"></i>
+        <i class="fas fa-sad-tear emoji-button"></i>
       <% elsif @mood == "6" %>
-        <i class="fas fa-tired emoji"></i>
+        <i class="fas fa-tired emoji-button"></i>
       <% elsif @mood == '' %>
-        <i class="fas fa-meh-blank"></i>
+        <i class="fas fa-meh-blank emoji-button"></i>
       <% end %>
-
+      </h4>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,7 +16,7 @@
       <% if user_signed_in? %>
 
         <li class="nav-item dropdown">
-          <i class="fas fa-user" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
+          <i class="fas fa-user avatar-icon" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "View Entries", entries_path, class: "dropdown-item" %>
             <%#= link_to "Settings", "#", class: "dropdown-item" %>


### PR DESCRIPTION
-Menu revisited to make Mood a different type of button
-Avatar icon resized to make it uniform w/ plus
-Buttons on doodle page spaced to 90vw

<img width="294" alt="Screen Shot 2021-06-02 at 1 54 33 PM" src="https://user-images.githubusercontent.com/78102899/120534942-67ea4980-c3b0-11eb-8e3d-cf6349affc9e.png">
<img width="319" alt="Screen Shot 2021-06-02 at 2 07 12 PM" src="https://user-images.githubusercontent.com/78102899/120534949-6a4ca380-c3b0-11eb-8e44-477ca0a370c9.png">
<img width="361" alt="Screen Shot 2021-06-02 at 2 40 52 PM" src="https://user-images.githubusercontent.com/78102899/120535081-8f411680-c3b0-11eb-8510-53a44364e8bb.png">
